### PR TITLE
split cache.go and drop ErrInvalid in favour of core.ErrInvalid 

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -4,28 +4,12 @@ package cache
 import (
 	"context"
 	"time"
-
-	"darvaza.org/slog"
 )
 
 var (
 	_ Getter = Cache(nil)
 	_ Setter = Cache(nil)
 )
-
-// A Store allows us to create or access Cache namespaces
-type Store interface {
-	// GetCache returns the named cache previously created with
-	// NewCache, or nil if there's no such namespace.
-	GetCache(name string) Cache
-	// NewCache creates a new Cache namespace
-	NewCache(name string, cacheBytes int64, getter Getter) Cache
-	// DeregisterCache removes a Cache namespace
-	DeregisterCache(name string)
-
-	// SetLogger binds the Store and its Cache namespaces to a logger
-	SetLogger(log slog.Logger)
-}
 
 // A Cache namespace
 type Cache interface {
@@ -40,55 +24,6 @@ type Cache interface {
 	Get(ctx context.Context, key string, dest Sink) error
 	// Remove removes an entry from the Cache
 	Remove(ctx context.Context, key string)
-}
-
-// Stats provides an snapshot on the state of a Cache namespace
-type Stats struct {
-	Bytes     int64
-	Items     int64
-	Gets      int64
-	Hits      int64
-	Evictions int64
-}
-
-// Type represetns a type of cache
-type Type int
-
-const (
-	// MainCache is the cache for items we own
-	MainCache Type = iota + 1
-	// HotCache is the cache for items that seem popular
-	// even if we don't necessarily own
-	HotCache
-)
-
-// Sink receives data from a Get call
-type Sink interface {
-	// SetString sets the value to s.
-	SetString(s string, e time.Time) error
-
-	// SetBytes sets the value to the contents of v.
-	// The caller retains ownership of v.
-	SetBytes(v []byte, e time.Time) error
-
-	// SetValue sets the value to the object v.
-	// The caller retains ownership of v.
-	SetValue(v any, e time.Time) error
-
-	// Bytes returns the value encoded as a slice
-	// of bytes
-	Bytes() []byte
-
-	// Len tells the length of the internally encoded
-	// representation of the value
-	Len() int
-
-	// Expire returns the time whe this entry will
-	// be evicted from the Cache
-	Expire() time.Time
-
-	// Reset empties the content of the Sink
-	Reset()
 }
 
 // A Getter loads data for a key.

--- a/cache.go
+++ b/cache.go
@@ -3,16 +3,9 @@ package cache
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"darvaza.org/slog"
-)
-
-var (
-	// ErrInvalid is returned by the Sink when the set
-	// value is of the wrong type
-	ErrInvalid = errors.New("invalid type")
 )
 
 var (

--- a/gob.go
+++ b/gob.go
@@ -60,7 +60,7 @@ func (sink *GobSink[T]) SetBytes(v []byte, e time.Time) error {
 // the Sink interface
 func (sink *GobSink[T]) SetString(string, time.Time) error {
 	sink.Reset()
-	return ErrInvalid
+	return core.ErrInvalid
 }
 
 // SetValue sets the object of the GobSink and its expiration time
@@ -69,7 +69,7 @@ func (sink *GobSink[T]) SetValue(v any, e time.Time) error {
 
 	p, ok := v.(*T)
 	if !ok {
-		return ErrInvalid
+		return core.ErrInvalid
 	}
 
 	enc := gob.NewEncoder(&buf)

--- a/sink.go
+++ b/sink.go
@@ -1,0 +1,34 @@
+package cache
+
+import (
+	"time"
+)
+
+// Sink receives data from a Get call
+type Sink interface {
+	// SetString sets the value to s.
+	SetString(s string, e time.Time) error
+
+	// SetBytes sets the value to the contents of v.
+	// The caller retains ownership of v.
+	SetBytes(v []byte, e time.Time) error
+
+	// SetValue sets the value to the object v.
+	// The caller retains ownership of v.
+	SetValue(v any, e time.Time) error
+
+	// Bytes returns the value encoded as a slice
+	// of bytes
+	Bytes() []byte
+
+	// Len tells the length of the internally encoded
+	// representation of the value
+	Len() int
+
+	// Expire returns the time whe this entry will
+	// be evicted from the Cache
+	Expire() time.Time
+
+	// Reset empties the content of the Sink
+	Reset()
+}

--- a/types.go
+++ b/types.go
@@ -1,0 +1,37 @@
+package cache
+
+import "darvaza.org/slog"
+
+// A Store allows us to create or access Cache namespaces
+type Store interface {
+	// GetCache returns the named cache previously created with
+	// NewCache, or nil if there's no such namespace.
+	GetCache(name string) Cache
+	// NewCache creates a new Cache namespace
+	NewCache(name string, cacheBytes int64, getter Getter) Cache
+	// DeregisterCache removes a Cache namespace
+	DeregisterCache(name string)
+
+	// SetLogger binds the Store and its Cache namespaces to a logger
+	SetLogger(log slog.Logger)
+}
+
+// Stats provides an snapshot on the state of a Cache namespace
+type Stats struct {
+	Bytes     int64
+	Items     int64
+	Gets      int64
+	Hits      int64
+	Evictions int64
+}
+
+// Type represents a type of cache
+type Type int
+
+const (
+	// MainCache is the cache for items we own
+	MainCache Type = iota + 1
+	// HotCache is the cache for items that seem popular
+	// even if we don't necessarily own
+	HotCache
+)

--- a/x/groupcache/groupcache.go
+++ b/x/groupcache/groupcache.go
@@ -87,7 +87,7 @@ func (p *Pool) NewCache(name string, cacheBytes int64, getter cache.Getter) cach
 
 		// unreachable
 		core.Panicf("groupcache[%q]: %s", name, "where is my sink??")
-		return cache.ErrInvalid
+		return core.ErrInvalid
 	}
 
 	if g := groupcache.NewGroup(name, cacheBytes,
@@ -155,7 +155,7 @@ func (g *Group) Get(ctx context.Context, key string, sink cache.Sink) error {
 	var b groupcache.ByteView
 
 	if sink == nil {
-		return cache.ErrInvalid
+		return core.ErrInvalid
 	}
 
 	// get a clean slate and attach sink to the context

--- a/x/protosink/go.mod
+++ b/x/protosink/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	darvaza.org/cache v0.2.9
-	darvaza.org/core v0.15.2 // indirect
+	darvaza.org/core v0.15.2
 	darvaza.org/slog v0.5.12 // indirect
 )
 

--- a/x/protosink/protosink.go
+++ b/x/protosink/protosink.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"darvaza.org/cache"
+	"darvaza.org/core"
 )
 
 var (
@@ -52,7 +53,7 @@ func (sink *ProtoSink) SetBytes(v []byte, e time.Time) error {
 	err := proto.Unmarshal(v, sink.out)
 	if err != nil {
 		sink.Reset()
-		return cache.ErrInvalid
+		return core.ErrInvalid
 	}
 
 	// store
@@ -73,14 +74,14 @@ func (sink *ProtoSink) SetValue(v any, e time.Time) error {
 	p, ok := v.(proto.Message)
 	if !ok {
 		sink.Reset()
-		return cache.ErrInvalid
+		return core.ErrInvalid
 	}
 
 	out, err := proto.Marshal(p)
 	if err != nil {
 		// failed to encode
 		sink.Reset()
-		return cache.ErrInvalid
+		return core.ErrInvalid
 	}
 
 	sink.b = out


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `Sink` interface for enhanced data management with expiration capabilities.
- **Bug Fixes**
	- Updated error handling across various components to ensure consistency and alignment with the core package.
- **Refactor**
	- Simplified the caching architecture by removing outdated interfaces and structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->