### PR TITLE
refactor Sink to use generics [BREAKING]

### DIFF
--- a/byte.go
+++ b/byte.go
@@ -1,0 +1,87 @@
+package cache
+
+import (
+	"time"
+
+	"darvaza.org/core"
+)
+
+var _ Sink = (*ByteSink)(nil)
+
+// ByteSink implements the simplest form of Sink
+type ByteSink struct {
+	bytes []byte
+	exp   time.Time
+}
+
+// Bytes returns the stored bytes
+func (s *ByteSink) Bytes() []byte {
+	if s != nil {
+		return s.bytes
+	}
+	return nil
+}
+
+// Len returns the length of the store bytes
+func (s *ByteSink) Len() int {
+	return len(s.Bytes())
+}
+
+// Expire indicates when the stored bytes are due to expire
+func (s *ByteSink) Expire() time.Time {
+	if s != nil {
+		return s.exp
+	}
+	return time.Time{}
+}
+
+// Reset blanks the stored data
+func (s *ByteSink) Reset() {
+	if s != nil {
+		// truncate
+		s.bytes = s.bytes[:0]
+		s.exp = time.Time{}
+	}
+}
+
+// SetBytes stores a copy of the given bytes and expiration date.
+func (s *ByteSink) SetBytes(b []byte, e time.Time) error {
+	switch {
+	case s == nil:
+		return core.ErrNilReceiver
+	case len(b) == 0:
+		return ErrNoData
+	default:
+		// store copy
+		s.copyBytes(b)
+		s.exp = e
+		return nil
+	}
+}
+
+func (s *ByteSink) copyBytes(b []byte) {
+	n := len(b)
+	if n <= cap(s.bytes) {
+		s.bytes = s.bytes[:n]
+	} else {
+		s.bytes = make([]byte, n)
+	}
+
+	copy(s.bytes, b)
+}
+
+// UnsafeSetBytes is like SetBytes but it uses the given byte slice
+// directly instead of making a copy.
+func (s *ByteSink) UnsafeSetBytes(b []byte, e time.Time) error {
+	switch {
+	case s == nil:
+		return core.ErrNilReceiver
+	case len(b) == 0:
+		return ErrNoData
+	default:
+		// store as-is
+		s.bytes = b
+		s.exp = e
+		return nil
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,8 @@
+package cache
+
+import "darvaza.org/core"
+
+var (
+	// ErrNoData indicates to data was provided.
+	ErrNoData = core.Wrap(core.ErrInvalid, "no data")
+)

--- a/sink.go
+++ b/sink.go
@@ -6,16 +6,9 @@ import (
 
 // Sink receives data from a Get call
 type Sink interface {
-	// SetString sets the value to s.
-	SetString(s string, e time.Time) error
-
 	// SetBytes sets the value to the contents of v.
 	// The caller retains ownership of v.
 	SetBytes(v []byte, e time.Time) error
-
-	// SetValue sets the value to the object v.
-	// The caller retains ownership of v.
-	SetValue(v any, e time.Time) error
 
 	// Bytes returns the value encoded as a slice
 	// of bytes
@@ -31,4 +24,18 @@ type Sink interface {
 
 	// Reset empties the content of the Sink
 	Reset()
+}
+
+// TSink extends [Sink] with type-specific SetValue/Value
+// methods.
+type TSink[T any] interface {
+	Sink
+
+	// SetValue sets the value to the object v.
+	// The caller retains ownership of v.
+	SetValue(v *T, e time.Time) error
+
+	// Value returns a copy of the object previously
+	// stored in the Sink.
+	Value() (*T, bool)
 }

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,30 @@
+package cache
+
+// DefaultClone attempts to make a safe copy of the given
+// object using interfaces.
+//
+// - Clone() *T
+// - Copy() *T
+// - Clone() T
+// - Copy() T
+func DefaultClone[T any](src *T) (*T, bool) {
+	if src == nil {
+		return nil, false
+	}
+
+	switch v := any(src).(type) {
+	case interface{ Clone() *T }:
+		return v.Clone(), true
+	case interface{ Copy() *T }:
+		return v.Copy(), true
+	case interface{ Clone() T }:
+		p := v.Clone()
+		return &p, true
+	case interface{ Copy() T }:
+		p := v.Copy()
+		return &p, true
+	default:
+		// TODO: safe shallow copy
+		return nil, false
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `ByteSink` type for managing byte data with expiration.
	- Added a `TSink` interface for type-safe value management.
	- Implemented a generic `DefaultClone` function for safe object copying.
	- Enhanced `ProtoSink` to handle Protobuf messages generically.

- **Bug Fixes**
	- Improved error handling in various methods across the `cache` package.

- **Refactor**
	- Simplified `GobSink` and `ProtoSink` implementations for better integration with `ByteSink`.
	- Removed outdated methods from the `Sink` interface to streamline functionality.

- **Documentation**
	- Added context-specific error variable `ErrNoData` for improved error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->