### PR TITLE
change Cache to use a generic comparable for keys [BREAKING]

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -7,56 +7,56 @@ import (
 )
 
 var (
-	_ Getter = Cache(nil)
-	_ Setter = Cache(nil)
+	_ Getter[string] = Cache[string](nil)
+	_ Setter[string] = Cache[string](nil)
 )
 
 // A Cache namespace
-type Cache interface {
+type Cache[K comparable] interface {
 	// Stats returns stats about the Cache namespace
 	Stats(Type) Stats
 	// Name returns the name of the cache
 	Name() string
 
 	// Set adds an entry to the Cache
-	Set(ctx context.Context, key string, value []byte, expire time.Time, cacheType Type) error
+	Set(ctx context.Context, key K, value []byte, expire time.Time, cacheType Type) error
 	// Get reads an entry into a Sink
-	Get(ctx context.Context, key string, dest Sink) error
+	Get(ctx context.Context, key K, dest Sink) error
 	// Remove removes an entry from the Cache
-	Remove(ctx context.Context, key string)
+	Remove(ctx context.Context, key K)
 }
 
 // A Getter loads data for a key.
-type Getter interface {
+type Getter[K comparable] interface {
 	// Get returns the value identified by key, populating dest.
 	//
 	// The returned data must be unversioned. That is, key must
 	// uniquely describe the loaded data, without an implicit
 	// current time, and without relying on cache expiration
 	// mechanisms.
-	Get(ctx context.Context, key string, dest Sink) error
+	Get(ctx context.Context, key K, dest Sink) error
 }
 
 // A GetterFunc implements Getter with a function.
-type GetterFunc func(ctx context.Context, key string, dest Sink) error
+type GetterFunc[K comparable] func(ctx context.Context, key K, dest Sink) error
 
 // Get allows a GetterFunc to implement the Getter interface
-func (f GetterFunc) Get(ctx context.Context, key string, dest Sink) error {
+func (f GetterFunc[K]) Get(ctx context.Context, key K, dest Sink) error {
 	return f(ctx, key, dest)
 }
 
 // A Setter stores data for a key
-type Setter interface {
-	Set(ctx context.Context, key string, value []byte,
+type Setter[K comparable] interface {
+	Set(ctx context.Context, key K, value []byte,
 		expire time.Time, cacheType Type) error
 }
 
 // A SetterFunc implements Setter with a function
-type SetterFunc func(ctx context.Context, key string, value []byte,
+type SetterFunc[K comparable] func(ctx context.Context, key K, value []byte,
 	expire time.Time, cacheType Type) error
 
 // Set allows a SetterFunc to implement the Setter interface
-func (f SetterFunc) Set(ctx context.Context, key string, value []byte,
+func (f SetterFunc[K]) Set(ctx context.Context, key K, value []byte,
 	expire time.Time, cacheType Type) error {
 	//
 	return f(ctx, key, value, expire, cacheType)

--- a/types.go
+++ b/types.go
@@ -3,12 +3,12 @@ package cache
 import "darvaza.org/slog"
 
 // A Store allows us to create or access Cache namespaces
-type Store interface {
+type Store[K comparable] interface {
 	// GetCache returns the named cache previously created with NewCache,
 	// or nil if there's no such namespace.
-	GetCache(name string) Cache
+	GetCache(name string) Cache[K]
 	// NewCache creates a new Cache namespace
-	NewCache(name string, cacheBytes int64, getter Getter) Cache
+	NewCache(name string, cacheBytes int64, getter Getter[K]) Cache[K]
 	// DeregisterCache removes a Cache namespace
 	DeregisterCache(name string)
 

--- a/x/groupcache/groupcache.go
+++ b/x/groupcache/groupcache.go
@@ -15,10 +15,10 @@ import (
 )
 
 var (
-	_ cache.Store  = (*HTTPPool)(nil)
-	_ http.Handler = (*HTTPPool)(nil)
-	_ cache.Store  = (*Pool)(nil)
-	_ cache.Cache  = (*Group)(nil)
+	_ cache.Store[string] = (*HTTPPool)(nil)
+	_ http.Handler        = (*HTTPPool)(nil)
+	_ cache.Store[string] = (*Pool)(nil)
+	_ cache.Cache[string] = (*Group)(nil)
 )
 
 // NewPool creates a Store placeholder to be used as entrypoint
@@ -77,7 +77,7 @@ func NewNoPeersPool() *Pool {
 }
 
 // NewCache creates a new Group
-func (p *Pool) NewCache(name string, cacheBytes int64, getter cache.Getter) cache.Cache {
+func (p *Pool) NewCache(name string, cacheBytes int64, getter cache.Getter[string]) cache.Cache[string] {
 	// wrap
 	fn := func(ctx context.Context, key string, dst groupcache.Sink) error {
 		sink, ok := ctxSink.Get(ctx)
@@ -100,7 +100,7 @@ func (p *Pool) NewCache(name string, cacheBytes int64, getter cache.Getter) cach
 // getBridged calls the getter using the Sink in the context, and then copies the
 // binary encoded representation in groupcache's Sink so it gets cached
 func (*Pool) getBridged(ctx context.Context, key string,
-	getter cache.Getter, sink cache.Sink, dst groupcache.Sink) error {
+	getter cache.Getter[string], sink cache.Sink, dst groupcache.Sink) error {
 	//
 	err := getter.Get(ctx, key, sink)
 	if err == nil {
@@ -111,7 +111,7 @@ func (*Pool) getBridged(ctx context.Context, key string,
 }
 
 // GetCache returns a named Group previously created
-func (*Pool) GetCache(name string) cache.Cache {
+func (*Pool) GetCache(name string) cache.Cache[string] {
 	if g := groupcache.GetGroup(name); g != nil {
 		return &Group{g}
 	}

--- a/x/memcache/cache.go
+++ b/x/memcache/cache.go
@@ -7,7 +7,9 @@ import (
 )
 
 var (
-	_ cache.Cache[string] = (*Cache[string])(nil)
+	_ cache.Cache[string]   = (*Cache[string])(nil)
+	_ cache.Cache[uint32]   = (*Cache[uint32])(nil)
+	_ cache.Cache[[32]byte] = (*Cache[[32]byte])(nil)
 )
 
 // Cache is a LRU with TTL [cache.Cache]

--- a/x/memcache/singleflight.go
+++ b/x/memcache/singleflight.go
@@ -13,6 +13,12 @@ import (
 var (
 	_ cache.Getter[string] = (*SingleFlight[string])(nil)
 	_ cache.Setter[string] = (*SingleFlight[string])(nil)
+
+	_ cache.Getter[uint64] = (*SingleFlight[uint64])(nil)
+	_ cache.Setter[uint64] = (*SingleFlight[uint64])(nil)
+
+	_ cache.Getter[[32]byte] = (*SingleFlight[[32]byte])(nil)
+	_ cache.Setter[[32]byte] = (*SingleFlight[[32]byte])(nil)
 )
 
 // SingleFlight is a man-in-the-middle between [cache.Cache] and

--- a/x/memcache/store.go
+++ b/x/memcache/store.go
@@ -10,7 +10,9 @@ import (
 )
 
 var (
-	_ cache.Store[string] = (*Store[string])(nil)
+	_ cache.Store[string]   = (*Store[string])(nil)
+	_ cache.Store[uint32]   = (*Store[uint32])(nil)
+	_ cache.Store[[32]byte] = (*Store[[32]byte])(nil)
 )
 
 // Store manages in-memory [cache.Cache]s


### PR DESCRIPTION
groupcache can only use strings though.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced generic type parameters for `Cache`, `Getter`, `Setter`, `Store`, and `SingleFlight` structures, enhancing type safety and flexibility for various key types.
	- Updated methods across packages to support generic keys, allowing for a broader range of key types while maintaining backward compatibility with string keys.

- **Bug Fixes**
	- Improved type safety in cache operations, reducing potential runtime errors related to type mismatches.

- **Documentation**
	- Enhanced clarity in method signatures and type definitions to reflect the new generic implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->