### PR TITLE
renovate: prevent Go updates beyond 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module darvaza.org/cache
 
 go 1.21
 
-toolchain go1.22.6
-
 require (
 	darvaza.org/core v0.15.4
 	darvaza.org/slog v0.5.14

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["golang-version"],
+      "allowedVersions": "1.21"
+    }
   ]
 }

--- a/x/groupcache/go.mod
+++ b/x/groupcache/go.mod
@@ -2,8 +2,6 @@ module darvaza.org/cache/x/groupcache
 
 go 1.21
 
-toolchain go1.22.6
-
 require (
 	darvaza.org/cache v0.3.2
 	darvaza.org/core v0.15.4

--- a/x/memcache/go.mod
+++ b/x/memcache/go.mod
@@ -2,8 +2,6 @@ module darvaza.org/cache/x/memcache
 
 go 1.21
 
-toolchain go1.22.6
-
 require (
 	darvaza.org/cache v0.3.2
 	darvaza.org/cache/x/simplelru v0.1.11

--- a/x/protosink/go.mod
+++ b/x/protosink/go.mod
@@ -2,8 +2,6 @@ module darvaza.org/cache/x/protosink
 
 go 1.21
 
-toolchain go1.22.6
-
 require (
 	darvaza.org/cache v0.3.2
 	darvaza.org/core v0.15.4

--- a/x/simplelru/go.mod
+++ b/x/simplelru/go.mod
@@ -2,8 +2,6 @@ module darvaza.org/cache/x/simplelru
 
 go 1.21
 
-toolchain go1.22.6
-
 require darvaza.org/core v0.15.4
 
 require (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration for the Renovate bot to manage package versions, allowing for more controlled versioning of Go packages.

- **Bug Fixes**
	- Removed the toolchain declaration across multiple modules, simplifying configuration and potentially aligning with the Go version specified.

- **Chores**
	- Updated dependencies in the `x/groupcache` module to include new versions for core packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->