### PR TITLE
feat(build): drop Go 1.21 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     strategy:
       matrix:
-        go: [ '1.21', '1.22', '1.23' ]
+        go: [ '1.22', '1.23' ]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,9 +40,9 @@ linters-settings:
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - dupl
     - errcheck
-    - exportloopref
     - goconst
     - gocyclo
     - gofmt

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ OUTDIR ?= $(TMPDIR)
 
 # Dynamic version selection based on Go version
 # Format: $(TOOLSDIR)/get_version.sh <go_version> <tool_version1> <tool_version2> ..
-GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.21 v1.59 v1.61)
-REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.21 v1.4)
+GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.22 v1.63.4)
+REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.22 v1.4)
 
 GOLANGCI_LINT_URL ?= github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 GOLANGCI_LINT ?= $(GO) run $(GOLANGCI_LINT_URL)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module darvaza.org/cache
 
-go 1.21
+go 1.22
 
 require (
 	darvaza.org/core v0.15.6

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "packageRules": [
     {
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "1.21"
+      "allowedVersions": "1.22"
     },
     {
       "groupName": "Darvaza Projects",

--- a/x/groupcache/go.mod
+++ b/x/groupcache/go.mod
@@ -1,6 +1,6 @@
 module darvaza.org/cache/x/groupcache
 
-go 1.21
+go 1.22
 
 require (
 	darvaza.org/cache v0.3.3

--- a/x/memcache/go.mod
+++ b/x/memcache/go.mod
@@ -1,6 +1,6 @@
 module darvaza.org/cache/x/memcache
 
-go 1.21
+go 1.22
 
 require (
 	darvaza.org/cache v0.3.3

--- a/x/protosink/go.mod
+++ b/x/protosink/go.mod
@@ -1,6 +1,6 @@
 module darvaza.org/cache/x/protosink
 
-go 1.21
+go 1.22
 
 require (
 	darvaza.org/cache v0.3.3

--- a/x/simplelru/go.mod
+++ b/x/simplelru/go.mod
@@ -1,6 +1,6 @@
 module darvaza.org/cache/x/simplelru
 
-go 1.21
+go 1.22
 
 require darvaza.org/core v0.15.6
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Chores**
  - Upgraded Go version from 1.21 to 1.22 across multiple project modules and configuration files
  - Updated GitHub Actions workflow to test Go versions 1.22 and 1.23
  - Modified linter configuration by adding `copyloopvar` and removing `exportloopref`
  - Updated development tool versions for golangci-lint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->