### PR TITLE
build: drop replace directives in favour of the go.work workspace

### DIFF
--- a/x/groupcache/go.mod
+++ b/x/groupcache/go.mod
@@ -3,7 +3,7 @@ module darvaza.org/cache/x/groupcache
 go 1.24.0
 
 require (
-	darvaza.org/cache v0.4.1
+	darvaza.org/cache v0.5.0
 	darvaza.org/core v0.19.1
 	darvaza.org/slog v0.9.1
 )
@@ -20,5 +20,3 @@ require (
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 )
-
-replace darvaza.org/cache => ../../

--- a/x/groupcache/go.sum
+++ b/x/groupcache/go.sum
@@ -1,3 +1,5 @@
+darvaza.org/cache v0.5.0 h1:GsfzGokqVyHtSh1Sp7hM++23aVRvuzh0fWcQcq5e/hk=
+darvaza.org/cache v0.5.0/go.mod h1:c8YvsczG6r0OE+A25k6bC8cDoMF3InX+x2YrDTk+8ZQ=
 darvaza.org/core v0.19.1 h1:Ea6zFi2STXt4QC7Jbu1/unUo5Kd/OX65flZgeNw2iOY=
 darvaza.org/core v0.19.1/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
 darvaza.org/slog v0.9.1 h1:AuHBg30wONVTq/roOyHzkWI1fYi39tn2Py+fUM1t53o=

--- a/x/memcache/go.mod
+++ b/x/memcache/go.mod
@@ -3,8 +3,8 @@ module darvaza.org/cache/x/memcache
 go 1.24.0
 
 require (
-	darvaza.org/cache v0.4.1
-	darvaza.org/cache/x/simplelru v0.2.1
+	darvaza.org/cache v0.5.0
+	darvaza.org/cache/x/simplelru v0.3.0
 	darvaza.org/core v0.19.1
 	darvaza.org/slog v0.9.1
 )
@@ -12,9 +12,4 @@ require (
 require (
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-)
-
-replace (
-	darvaza.org/cache => ../..
-	darvaza.org/cache/x/simplelru => ../simplelru
 )

--- a/x/memcache/go.sum
+++ b/x/memcache/go.sum
@@ -1,3 +1,7 @@
+darvaza.org/cache v0.5.0 h1:GsfzGokqVyHtSh1Sp7hM++23aVRvuzh0fWcQcq5e/hk=
+darvaza.org/cache v0.5.0/go.mod h1:c8YvsczG6r0OE+A25k6bC8cDoMF3InX+x2YrDTk+8ZQ=
+darvaza.org/cache/x/simplelru v0.3.0 h1:z7wd6Q42qAnx8x6hIBV1zuQCMV8lD14AmPjS8uuCdZU=
+darvaza.org/cache/x/simplelru v0.3.0/go.mod h1:l6OrxhBHk5/TH1P/hRmRLFru2vrdDBNCXH9xUrE6axM=
 darvaza.org/core v0.19.1 h1:Ea6zFi2STXt4QC7Jbu1/unUo5Kd/OX65flZgeNw2iOY=
 darvaza.org/core v0.19.1/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
 darvaza.org/slog v0.9.1 h1:AuHBg30wONVTq/roOyHzkWI1fYi39tn2Py+fUM1t53o=

--- a/x/protosink/go.mod
+++ b/x/protosink/go.mod
@@ -3,7 +3,7 @@ module darvaza.org/cache/x/protosink
 go 1.24.0
 
 require (
-	darvaza.org/cache v0.4.1
+	darvaza.org/cache v0.5.0
 	darvaza.org/core v0.19.1
 	darvaza.org/slog v0.9.1 // indirect
 )
@@ -15,5 +15,3 @@ require (
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 )
-
-replace darvaza.org/cache => ../../

--- a/x/protosink/go.sum
+++ b/x/protosink/go.sum
@@ -1,3 +1,5 @@
+darvaza.org/cache v0.5.0 h1:GsfzGokqVyHtSh1Sp7hM++23aVRvuzh0fWcQcq5e/hk=
+darvaza.org/cache v0.5.0/go.mod h1:c8YvsczG6r0OE+A25k6bC8cDoMF3InX+x2YrDTk+8ZQ=
 darvaza.org/core v0.19.1 h1:Ea6zFi2STXt4QC7Jbu1/unUo5Kd/OX65flZgeNw2iOY=
 darvaza.org/core v0.19.1/go.mod h1:8+rhinVhCzJf814uPOYFRmj1D+8mO7bkbo/hrK0Lmkk=
 darvaza.org/slog v0.9.1 h1:AuHBg30wONVTq/roOyHzkWI1fYi39tn2Py+fUM1t53o=


### PR DESCRIPTION
## Summary

The `x/*` submodules carried `replace` directives pointing at sibling
working trees (`darvaza.org/cache => ../..`, etc.). Those are redundant
with the shared `go.work` at the development-tree root, which already
lists every cache module, and they make cache the only darvaza
repository still using committed replaces — every sibling (`darvaza.org/x`,
`core`, …) relies on the workspace alone.

This drops the replace directives and lets the workspace provide local
cross-module resolution, leaving each module's `require` block as the
single source of truth. A committed replace silently masks a stale
`require` version; without it, `go mod tidy` and CI resolve the real
published modules, so the declared versions can no longer drift unnoticed.

## Changes

- Remove `replace` directives from `groupcache`, `memcache` and
  `protosink`.
- Point the submodules at the freshly published leaves:
  `darvaza.org/cache` v0.4.1 → v0.5.0 (all three) and
  `darvaza.org/cache/x/simplelru` v0.2.1 → v0.3.0 (memcache).
- `go.sum` gains the leaf checksums the replaces were masking.

## Verification

- `make tidy` and `make all race` are green across all five modules.
- Built each submodule with `GOWORK=off` — i.e. exactly as CI sees it,
  with no workspace checked out — and all resolve the published leaves
  from the proxy and build cleanly.

## Context

Part of the Go 1.24 floor release. The leaves (`v0.5.0`,
`x/simplelru/v0.3.0`) are already tagged and published; the dependent
tags (`x/groupcache/v0.4.0`, `x/memcache/v0.4.0`, `x/protosink/v0.3.0`)
will be cut on `main` once this merges, so they capture the
replace-free go.mods.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated cache module dependencies to v0.5.0 across multiple packages
  * Updated simplelru cache module to v0.3.0
  * Removed local development path overrides in favor of published versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->